### PR TITLE
fix(README): 修复 Star 历史图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,4 +131,4 @@
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=l429609201/misaka_danmu_server&type=Date)](https://www.star-history.com/#l429609201/misaka_danmu_server&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=l429609201/misaka_danmu_server&type=Date)](https://star-history.dera.page/#l429609201/misaka_danmu_server&Date)


### PR DESCRIPTION
README 中的 Star 历史图表目前因 GitHub Stargazer API 限制而失效，已无法正常渲染。本次修改将图表地址切换到可用的镜像源，保证图表可以正常显示，不影响其他功能。